### PR TITLE
gitignore: add src/*.key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 *.x86_64
 *.hex
 src/dsvpn
+src/*.key
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
I figured that a lot of people will generate a `vpn.key` or something similar.