### PR TITLE
fix compilation problem

### DIFF
--- a/src/charm.c
+++ b/src/charm.c
@@ -111,6 +111,7 @@ static inline void endian_swap_rate(uint32_t st[12])
 {
     (void) st;
 #ifdef NATIVE_BIG_ENDIAN
+    size_t i;
     for (i = 0; i < 4; i++) {
         st[i] = __builtin_bswap32(st[i]);
     }
@@ -121,6 +122,7 @@ static inline void endian_swap_all(uint32_t st[12])
 {
     (void) st;
 #ifdef NATIVE_BIG_ENDIAN
+    size_t i;
     for (i = 0; i < 12; i++) {
         st[i] = __builtin_bswap32(st[i]);
     }


### PR DESCRIPTION
I need to add a missing definition in order to compile dsvpn for mips platform on openvpn.