### PR TITLE
Allow tun autodetection on FreeBSD

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -152,7 +152,7 @@ int tun_create(char if_name[IFNAMSIZ], const char *wanted_name)
     }
     return tun_create_by_id(if_name, id);
 }
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
 int tun_create(char if_name[IFNAMSIZ], const char *wanted_name)
 {
     char         path[64];


### PR DESCRIPTION
The OpenBSD autodetection mechanism also works with FreeBSD