### PR TITLE
Fix default external iface on FreeBSD

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -333,7 +333,10 @@ const char *get_default_ext_if_name(void)
 #elif defined(__linux__)
     return read_from_shell_command(if_name, sizeof if_name,
                                    "ip route show default 2>/dev/null|awk '/default/{print $5}'");
-#elif defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(__FreeBSD__)
+    return read_from_shell_command(if_name, sizeof if_name,
+                                   "route get default | awk '$1 == \"interface:\" {print $2}'");
+#elif defined(__OpenBSD__)
     return read_from_shell_command(if_name, sizeof if_name,
                                    "netstat -rn|awk '/^default/{print $8}'");
 #else


### PR DESCRIPTION
FreeBSD netstat -rn output is different from OpenBSD, the field to use
would be the 4th field and not the 8th field like on OpenBSD.
FreeBSD auto allow to direct query for a given route (including default)
so let's directly use the direct query instead of using netstat -rn