### PR TITLE
Only strip binary at install time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ all: dsvpn
 
 dsvpn: Makefile src/vpn.c src/charm.c src/os.c include/charm.h include/vpn.h include/os.h
 	$(CC) $(CFLAGS) -Iinclude -o $@ src/vpn.c src/charm.c src/os.c
-	strip $@
 
 install: dsvpn
-	install -m 0755 dsvpn $(PREFIX)/sbin
+	install -s -m 0755 dsvpn $(PREFIX)/sbin
 
 uninstall:
 	rm $(PREFIX)/sbin/dsvpn


### PR DESCRIPTION
Instead of stripping the binary at build time, do it at install time
via the -s flag from install(1)

It allows to keep a non stripped binary in the working directory:
useful to debug
It allows the build system to by pass the stipping command if they want
as install(1) allow to control wether or not to strip via environnement
variable