### PR TITLE
Fix some casting, correct /32 for external IP on Mac

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -294,7 +294,7 @@ static char *read_from_shell_command(char *result, size_t sizeof_result, const c
     if ((fp = popen(command, "r")) == NULL) {
         return NULL;
     }
-    if (fgets(result, sizeof_result, fp) == NULL) {
+    if (fgets(result, (int) sizeof_result, fp) == NULL) {
         pclose(fp);
         fprintf(stderr, "Command [%s] failed]\n", command);
         return NULL;
@@ -432,7 +432,7 @@ int shell_cmd(const char *substs[][2], const char *args_str, int silent)
         }
         execvp(args[0], args);
         _exit(1);
-    } else if (waitpid(child, &exit_status, 0) == (pid_t) -1 || !WIFEXITED(exit_status)) {
+    } else if (waitpid(child, &exit_status, WNOHANG|WUNTRACED) == (pid_t) -1 || !WIFEXITED(exit_status)) {
         return -1;
     }
     return 0;
@@ -476,7 +476,7 @@ Cmds firewall_rules_cmds(int is_server)
         static const char *set_cmds[] =
             { "ifconfig $IF_NAME $LOCAL_TUN_IP $REMOTE_TUN_IP up",
               "ifconfig $IF_NAME inet6 $LOCAL_TUN_IP6 $REMOTE_TUN_IP6 prefixlen 128 up",
-              "route add $EXT_IP $EXT_GW_IP",
+              "route add $EXT_IP/32 $EXT_GW_IP",
               "route add 0/1 $REMOTE_TUN_IP",
               "route add 128/1 $REMOTE_TUN_IP",
               "route add -inet6 -blackhole 0000::/1 $REMOTE_TUN_IP6",

--- a/src/os.c
+++ b/src/os.c
@@ -432,7 +432,7 @@ int shell_cmd(const char *substs[][2], const char *args_str, int silent)
         }
         execvp(args[0], args);
         _exit(1);
-    } else if (waitpid(child, &exit_status, WNOHANG|WUNTRACED) == (pid_t) -1 || !WIFEXITED(exit_status)) {
+    } else if (waitpid(child, &exit_status, WNOHANG) == (pid_t) -1 || !WIFEXITED(exit_status)) {
         return -1;
     }
     return 0;
@@ -476,7 +476,7 @@ Cmds firewall_rules_cmds(int is_server)
         static const char *set_cmds[] =
             { "ifconfig $IF_NAME $LOCAL_TUN_IP $REMOTE_TUN_IP up",
               "ifconfig $IF_NAME inet6 $LOCAL_TUN_IP6 $REMOTE_TUN_IP6 prefixlen 128 up",
-              "route add $EXT_IP/32 $EXT_GW_IP",
+              "route add $EXT_IP $EXT_GW_IP",
               "route add 0/1 $REMOTE_TUN_IP",
               "route add 128/1 $REMOTE_TUN_IP",
               "route add -inet6 -blackhole 0000::/1 $REMOTE_TUN_IP6",

--- a/src/vpn.c
+++ b/src/vpn.c
@@ -539,7 +539,7 @@ static int resolve_ip(char *ip, size_t sizeof_ip, const char *ip_or_name)
     hints.ai_addr     = NULL;
     if ((eai = getaddrinfo(ip_or_name, NULL, &hints, &res)) != 0 ||
         (res->ai_family != AF_INET && res->ai_family != AF_INET6) ||
-        (eai = getnameinfo(res->ai_addr, res->ai_addrlen, ip, sizeof_ip, NULL, 0,
+        (eai = getnameinfo(res->ai_addr, res->ai_addrlen, ip, (int) sizeof_ip, NULL, 0,
                            NI_NUMERICHOST | NI_NUMERICSERV)) != 0) {
         fprintf(stderr, "Unable to resolve [%s]: [%s]\n", ip_or_name, gai_strerror(eai));
         return -1;

--- a/src/vpn.c
+++ b/src/vpn.c
@@ -539,7 +539,7 @@ static int resolve_ip(char *ip, size_t sizeof_ip, const char *ip_or_name)
     hints.ai_addr     = NULL;
     if ((eai = getaddrinfo(ip_or_name, NULL, &hints, &res)) != 0 ||
         (res->ai_family != AF_INET && res->ai_family != AF_INET6) ||
-        (eai = getnameinfo(res->ai_addr, res->ai_addrlen, ip, (int) sizeof_ip, NULL, 0,
+        (eai = getnameinfo(res->ai_addr, res->ai_addrlen, ip, (socklen_t) sizeof_ip, NULL, 0,
                            NI_NUMERICHOST | NI_NUMERICSERV)) != 0) {
         fprintf(stderr, "Unable to resolve [%s]: [%s]\n", ip_or_name, gai_strerror(eai));
         return -1;


### PR DESCRIPTION
Was trying out importing into Xcode on Mac, and had a few items it suggested to fix (int for ssize_t casting).

I was also getting interrupted system calls from `execvp` when running in the Xcode debugger. Solution was to change the `waitpid` options.

Lastly, there was a missing /32 netmask for the external IP when creating routing on Mac.