### PR TITLE
Fix a resource leak (socket leaked on error)

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -204,6 +204,7 @@ int tun_set_mtu(const char *if_name, int mtu)
     ifr.ifr_mtu = mtu;
     snprintf(ifr.ifr_name, IFNAMSIZ, "%s", if_name);
     if (ioctl(fd, SIOCSIFMTU, &ifr) != 0) {
+        close(fd);
         return -1;
     }
     return close(fd);


### PR DESCRIPTION
This patch fixes a resource leak.

The bug was detected with Muse - a static analysis tool platform for CI.  Without any configuration on this repo it automatically runs Infer - a separation logic tool focused on heap structures and locks.  I could e-mail you an activation code for us to turn it on in this repo if you'd like.