### PR TITLE
valid base64 parameter for all os.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If required, keys can be exported and imported in printable form:
 
 ```sh
 base64 < vpn.key
-echo 'HK940OkWcFqSmZXnCQ1w6jhQMZm0fZoEhQOOpzJ/l3w=' | base64 -d > vpn.key
+echo 'HK940OkWcFqSmZXnCQ1w6jhQMZm0fZoEhQOOpzJ/l3w=' | base64 --decode > vpn.key
 ```
 
 ## Example usage on the server


### PR DESCRIPTION
`-D` parameter is not valid on osx and in both `--decode` is a valid code.


**On linux:**
```
>> base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit
```

**On osx:**
```
>> base64 --help                                                                                                                                               syny@synys-MacBook-Air
Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -D, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```