### PR TITLE
Idiotproof usage

### DIFF
--- a/src/vpn.c
+++ b/src/vpn.c
@@ -513,7 +513,11 @@ __attribute__((noreturn)) static void usage(void)
          "\n\n"
          "dsvpn\t\"client\"\n\t<key file>\n\t<vpn server ip or name>\n\t<vpn server "
          "port>|\"auto\"\n\t<tun interface>|\"auto\"\n\t<local tun "
-         "ip>|\"auto\"\n\t<remote tun ip>|\"auto\"\n\t<gateway ip>|\"auto\"\n");
+         "ip>|\"auto\"\n\t<remote tun ip>|\"auto\"\n\t<gateway ip>|\"auto\"\n\n"
+         "Example:\n\n[server]\n\tdd if=/dev/urandom of=vpn.key count=1 bs=32\n"
+         "\t# copy key\n\tbase64 < vpn.key\n\t# listen on 443\n\tsudo ./dsvpn server vpn.key\n\n"
+         "[client]\n\t# paste key\n\techo ohKD...W4= | base64 --decode > vpn.key\n"
+         "\tsudo ./dsvpn client vpn.key 34.216.127.34\n");
     exit(254);
 }
 


### PR DESCRIPTION
First - I know this is kind of a wanky commit. But in my opinion - dsvpn killer feature is the usage screen. Everything is up front and is a no brainer.

Just thought in the spirit of having all the documentation upfront in the usage, it'd probably help to remind people how to generate a key and specifically it is 32 bytes. Trivialises how to use base64. Personally I'm always confused whether it is: `base64 -e|--encode` (and it's neither) and `base64 -d|-D|--decode` (first option is wrong). Great to have it right in front of me.

~And if you think this is acceptable to add to the usage, maybe I should clarify decode usage:~ (added it anyway)
```
echo ohKD...W4= | base64 --decode > vpn.key
```

If this is something you want to add - do you think it'd help to turn this directly into an example using the instructions from README.md.

Like maybe:

```
DSVPN 0.1.3 usage:

dsvpn	"server"
	<key file>
	<vpn server ip or name>|"auto"
	<vpn server port>|"auto"
	<tun interface>|"auto"
	<local tun ip>|"auto"
	<remote tun ip>"auto"
	<external ip>|"auto"

dsvpn	"client"
	<key file>
	<vpn server ip or name>
	<vpn server port>|"auto"
	<tun interface>|"auto"
	<local tun ip>|"auto"
	<remote tun ip>|"auto"
	<gateway ip>"auto"

Example usage:

[on server]
	dd if=/dev/urandom of=vpn.key count=1 bs=32
	# copy key
	base64 < vpn.key
	# listen on 443
	sudo ./dsvpn server vpn.key auto

[on client]
	# paste key
	echo ohKD...W4= | base64 --decode > vpn.key
	sudo ./dsvpn client vpn.key 34.216.127.34
```