### PR TITLE
Makefile: install command installs into sbin/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dsvpn: $(CFLAGS_FILE) Makefile src/vpn.c src/charm.c src/os.c include/charm.h in
 	strip $@
 
 install: dsvpn
-	install -m 0755 dsvpn $(PREFIX)/sbin
+	install -m 0755 dsvpn $(PREFIX)/sbin/
 
 uninstall:
 	rm $(PREFIX)/sbin/dsvpn


### PR DESCRIPTION
The install command at the moment installs to "sbin" without
instead of "sbin/". This frustrates packaging because in the
former a file can be created whereas in the latter if the
directory doesn't exist make will fail.

The latter is of course the desirable choice. Nobody wants
to install a dsvpn binary called sbin.