### PR TITLE
Fix remote tun IP config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dsvpn   "server"
         <vpn server port>|"auto"
         <tun interface>|"auto"
         <local tun ip>|"auto"
-        <remote tun ip>"auto"
+        <remote tun ip>|"auto"
         <external ip>|"auto"
 
 dsvpn   "client"


### PR DESCRIPTION
## Summary
- fix formatting for `<remote tun ip>` config example

## Testing
- `make`
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848258ca14c8320ab99fd573f3539a8