### PR TITLE
Update Zig build script to Zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -7,15 +6,17 @@ pub fn build(b: *std.Build) !void {
 
     const dsvpn = b.addExecutable(.{
         .name = "dsvpn",
-        .target = target,
-        .optimize = optimize,
-        .strip = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .strip = true,
+        }),
     });
-    dsvpn.linkLibC();
-    dsvpn.addIncludePath(b.path("include"));
+    dsvpn.root_module.link_libc = true;
+    dsvpn.root_module.addIncludePath(b.path("include"));
     dsvpn.root_module.addCMacro("_GNU_SOURCE", "1");
     const source_files = &.{ "src/charm.c", "src/os.c", "src/vpn.c" };
-    dsvpn.addCSourceFiles(.{ .files = source_files });
+    dsvpn.root_module.addCSourceFiles(.{ .files = source_files });
     b.installArtifact(dsvpn);
     const run_cmd = b.addRunArtifact(dsvpn);
     run_cmd.step.dependOn(b.getInstallStep());


### PR DESCRIPTION
Update `build.zig` to build with Zig 0.15.1.

- Use equivalent `Build.Module` methods in place of deprecated `Build.Step.Compile` ones.
- Remove unnecessary `builtin` import - As far as I can tell, this isn't needed.
